### PR TITLE
Fix path creation for artists whose names contain path characters

### DIFF
--- a/beetsplug/fetchartist.py
+++ b/beetsplug/fetchartist.py
@@ -123,7 +123,7 @@ class FetchArtistPlugin(plugins.BeetsPlugin):
         else:
             template = self._default_template
 
-        evaluated_template = item.evaluate_template(template)
+        evaluated_template = item.evaluate_template(template, True)
         cover_name = self._get_cover_name(item)
         path = os.path.join(evaluated_template, cover_name)
 


### PR DESCRIPTION
For example, `The World/Inferno Friendship Society` needs to have the `/` transformed, which is done by the `for_path` argument to `evaluate_template` here.