### PR TITLE
Expand ~ in path

### DIFF
--- a/beetsplug/fetchartist.py
+++ b/beetsplug/fetchartist.py
@@ -127,7 +127,7 @@ class FetchArtistPlugin(plugins.BeetsPlugin):
         cover_name = self._get_cover_name(item)
         path = os.path.join(evaluated_template, cover_name)
 
-        return os.path.join(self._library_path, beetsutil.sanitize_path(path))
+        return os.path.expanduser(os.path.join(self._library_path, beetsutil.sanitize_path(path)))
 
     def _create_artist_infos(self, items):
         artist_infos = dict()


### PR DESCRIPTION
Fixes for example a library at `~/music` needing to have the full path for writing/reading.